### PR TITLE
nicer console behaviour when download is finished

### DIFF
--- a/ex-dl.py
+++ b/ex-dl.py
@@ -72,7 +72,7 @@ def download(fileurl,file_name):
         #print status
         sys.stdout.write("\r        %s" % status)
         sys.stdout.flush()
-        
+    sys.stdout.write("\n")        
     f.close()
 
 if __name__ == '__main__':


### PR DESCRIPTION
(On mac os x at least) When the script finishes, it overwrites the download progress, rather than jumping to a newline.
This makes the console output a little nicer.
